### PR TITLE
Added ability to pull in slides from gists

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Make lightning talks for the cli
 
 ## Usage
 
-`deck-lightning 90 one.md two.md three.md > talk.html`
+`deck-lightning 90 one.md two.md "https://gist.github.com/path_to_some_gist" four.md > talk.html`
 
-This will create a three slide presentation where one.md is the first slide and three.md is the last and each slide is on the screen for 90 seconds
+This will create a four slide presentation where one.md is the first slide, the gist at the above URL is the 3rd slide,  four.md is the last content slide and each slide is on the screen for 90 seconds.  After the last content slide, a static "Thanks" slide is presented.
 

--- a/index.js
+++ b/index.js
@@ -16,28 +16,27 @@ module.exports = function(opts, cb){
 	var i = 0;
 	opts.files.forEach(function(file){
 		i++;
-		fs.readFile(file, "utf8", function(err, md){
-			if(err){
-				cb(err);
-				cb = function(){};
-			}
-			else{
-				var content =  marked(md);
-				ejsOpts.slides.push({
-					title: file,
-					content: content
-				});
-				i--;
-				done();
-			}
-		});
+    if (file.indexOf('https://gist.github.com/') == 0) {
+          generateSlide(file, '<script src="' + file + '"></script>');
+    }
+    else {
+      md = fs.readFileSync(file, {encoding: "utf8"});
+      generateSlide(file, marked(md));
+    }
 	});
+  done();
+
+  function generateSlide(title, content){
+    ejsOpts.slides.push({
+      title: title,
+      content: content
+    });
+  };
 
 	function done(){
-		if(i==0){
-			var html = ejs.render(template, ejsOpts);
-			cb(null, html);
-		}
+    generateSlide('The End', marked('# Thanks!\n[The beginning](#slide-0)'));
+    var html = ejs.render(template, ejsOpts);
+    cb(null, html);
 	}
 }
 


### PR DESCRIPTION
Note that in order to do so and have things stay in order, I ended
up having to remove the async calls to readFile and make them
readFileSync instead.  Will make things slightly slower when
building from lots of disk files (and is "un-node-like"), but for
quick-and-dirty inclusion of gists it works.

Also added in a final end-of-deck slide that loops and includes a link back to the beginning
